### PR TITLE
Fix to catch connection errors

### DIFF
--- a/ngrok.js
+++ b/ngrok.js
@@ -28,10 +28,15 @@ module.exports = function(RED) {
             clean(options);
             if (msg.payload == 'on'){
               (async function(){
+                try{
                   const url = await ng.connect(options);
                   msg.payload = url;
                   node.send(msg);
                   node.status({fill:"green",shape:"dot",text:url});
+                }catch(e){
+                  node.error(e);
+                  node.status({fill:"red",shape:"dot",text: "connnect error"});
+                }
               })();
           }
           else if (msg.payload == 'off'){


### PR DESCRIPTION
Fixed to catch an error when connecting to ngrok due to a token error.

<img width="825" alt="スクリーンショット 2019-11-10 15 44 33" src="https://user-images.githubusercontent.com/23309/68540174-07ac4500-03d1-11ea-9a91-bab4c233fd9f.png">

## Error Message on The Terminal
```
(node:87258) UnhandledPromiseRejectionWarning: Error: connect ECONNREFUSED 127.0.0.1:4040
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1113:14)
warning.js:18
(node:87258) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
warning.js:18
(node:87258) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
warning.js:18
```